### PR TITLE
Simplify Artifact Handling and Upgrade to actions/*-artifact@v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,7 @@ jobs:
         echo "EMUFRAMEWORK_PATH=${{ github.workspace }}/EmuFramework" >> $GITHUB_ENV
         echo "IMAGINE_PATH=${{ github.workspace }}/imagine" >> $GITHUB_ENV
         echo "IMAGINE_SDK_PATH=${{ github.workspace }}/imagine-sdk" >> $GITHUB_ENV
+        echo "COMMIT_PREFIX=$(echo ${{ github.sha }} | cut -c1-8)" >> $GITHUB_ENV
 
     - name: Run script
       run: |
@@ -69,293 +70,117 @@ jobs:
       run: |
         cd 2600.emu
         make -f android-release.mk android-apk V=1 -j`nproc`
-
-    - name: Copy 2600.emu artifact
-      if: ${{ matrix.image == '2600.emu' }}
-      run: |
-        cp 2600.emu/target/android-release/build/outputs/apk/release/2600Emu-release.apk EX-Emulators/2600Emu-release.apk
-
-    - name: Upload 2600.emu artifact
-      uses: actions/upload-artifact@v3
-      if: ${{ matrix.image == '2600.emu' }}
-      with:
-        name: 2600emu
-        path: ${{ github.workspace }}/2600.emu/target/android-release/build/outputs/apk/release/2600Emu-release.apk
+        cp target/android-release/build/outputs/apk/release/2600Emu-release.apk "../EX-Emulators/2600Emu-${COMMIT_PREFIX}.apk"
 
     - name: Build C64.emu
       if: ${{ matrix.image == 'C64.emu' }}
       run: |
         cd C64.emu
         make -f android-release.mk android-apk V=1 -j`nproc`
-
-    - name: Copy C64.emu artifact
-      if: ${{ matrix.image == 'C64.emu' }}
-      run: |
-        cp C64.emu/target/android-release/build/outputs/apk/release/C64Emu-release.apk EX-Emulators/C64Emu-release.apk
-
-    - name: Upload C64.emu artifact
-      uses: actions/upload-artifact@v3
-      if: ${{ matrix.image == 'C64.emu' }}
-      with:
-        name: C64emu
-        path: ${{ github.workspace }}/C64.emu/target/android-release/build/outputs/apk/release/C64Emu-release.apk
+        cp target/android-release/build/outputs/apk/release/C64Emu-release.apk "../EX-Emulators/C64Emu-${COMMIT_PREFIX}.apk"
 
     - name: Build GBA.emu
       if: ${{ matrix.image == 'GBA.emu' }}
       run: |
         cd GBA.emu
         make -f android-release.mk android-apk V=1 -j`nproc`
-
-    - name: Copy GBA.emu artifact
-      if: ${{ matrix.image == 'GBA.emu' }}
-      run: |
-        cp GBA.emu/target/android-release/build/outputs/apk/release/GbaEmu-release.apk EX-Emulators/GbaEmu-release.apk
-
-    - name: Upload GBA.emu artifact
-      uses: actions/upload-artifact@v3
-      if: ${{ matrix.image == 'GBA.emu' }}
-      with:
-        name: GBAemu
-        path: ${{ github.workspace }}/GBA.emu/target/android-release/build/outputs/apk/release/GbaEmu-release.apk
+        cp target/android-release/build/outputs/apk/release/GbaEmu-release.apk "../EX-Emulators/GbaEmu-${COMMIT_PREFIX}.apk"
 
     - name: Build GBC.emu
       if: ${{ matrix.image == 'GBC.emu' }}
       run: |
         cd GBC.emu
         make -f android-release.mk android-apk V=1 -j`nproc`
-
-    - name: Copy GBC.emu artifact
-      if: ${{ matrix.image == 'GBC.emu' }}
-      run: |
-        cp GBC.emu/target/android-release/build/outputs/apk/release/GbcEmu-release.apk EX-Emulators/GbcEmu-release.apk
-
-    - name: Upload GBC.emu artifact
-      uses: actions/upload-artifact@v3
-      if: ${{ matrix.image == 'GBC.emu' }}
-      with:
-        name: GBCemu
-        path: ${{ github.workspace }}/GBC.emu/target/android-release/build/outputs/apk/release/GbcEmu-release.apk
+        cp target/android-release/build/outputs/apk/release/GbcEmu-release.apk "../EX-Emulators/GbcEmu-${COMMIT_PREFIX}.apk"
 
     - name: Build Lynx.emu
       if: ${{ matrix.image == 'Lynx.emu' }}
       run: |
         cd Lynx.emu
         make -f android-release.mk android-apk V=1 -j`nproc`
-
-    - name: Copy Lynx.emu artifact
-      if: ${{ matrix.image == 'Lynx.emu' }}
-      run: |
-        cp Lynx.emu/target/android-release/build/outputs/apk/release/LynxEmu-release.apk EX-Emulators/LynxEmu-release.apk
-
-    - name: Upload Lynx.emu artifact
-      uses: actions/upload-artifact@v3
-      if: ${{ matrix.image == 'Lynx.emu' }}
-      with:
-        name: Lynxemu
-        path: ${{ github.workspace }}/Lynx.emu/target/android-release/build/outputs/apk/release/LynxEmu-release.apk
+        cp target/android-release/build/outputs/apk/release/LynxEmu-release.apk "../EX-Emulators/LynxEmu-${COMMIT_PREFIX}.apk"
 
     - name: Build MD.emu
       if: ${{ matrix.image == 'MD.emu' }}
       run: |
         cd MD.emu
         make -f android-release.mk android-apk V=1 -j`nproc`
-
-    - name: Copy MD.emu artifact
-      if: ${{ matrix.image == 'MD.emu' }}
-      run: |
-        cp MD.emu/target/android-release/build/outputs/apk/release/MdEmu-release.apk EX-Emulators/MdEmu-release.apk
-
-    - name: Upload MD.emu artifact
-      uses: actions/upload-artifact@v3
-      if: ${{ matrix.image == 'MD.emu' }}
-      with:
-        name: MDemu
-        path: ${{ github.workspace }}/MD.emu/target/android-release/build/outputs/apk/release/MdEmu-release.apk
+        cp target/android-release/build/outputs/apk/release/MdEmu-release.apk "../EX-Emulators/MdEmu-${COMMIT_PREFIX}.apk"
 
     - name: Build MSX.emu
       if: ${{ matrix.image == 'MSX.emu' }}
       run: |
         cd MSX.emu
         make -f android-release.mk android-apk V=1 -j`nproc`
-
-    - name: Copy MSX.emu artifact
-      if: ${{ matrix.image == 'MSX.emu' }}
-      run: |
-        cp MSX.emu/target/android-release/build/outputs/apk/release/MsxEmu-release.apk EX-Emulators/MsxEmu-release.apk
-
-    - name: Upload MSX.emu artifact
-      uses: actions/upload-artifact@v3
-      if: ${{ matrix.image == 'MSX.emu' }}
-      with:
-        name: MSXemu
-        path: ${{ github.workspace }}/MSX.emu/target/android-release/build/outputs/apk/release/MsxEmu-release.apk
+        cp target/android-release/build/outputs/apk/release/MsxEmu-release.apk "../EX-Emulators/MsxEmu-${COMMIT_PREFIX}.apk"
 
     - name: Build NEO.emu
       if: ${{ matrix.image == 'NEO.emu' }}
       run: |
         cd NEO.emu
         make -f android-release.mk android-apk V=1 -j`nproc`
-
-    - name: Copy NEO.emu artifact
-      if: ${{ matrix.image == 'NEO.emu' }}
-      run: |
-        cp NEO.emu/target/android-release/build/outputs/apk/release/NeoEmu-release.apk EX-Emulators/NeoEmu-release.apk
-
-    - name: Upload NEO.emu artifact
-      uses: actions/upload-artifact@v3
-      if: ${{ matrix.image == 'NEO.emu' }}
-      with:
-        name: NEOemu
-        path: ${{ github.workspace }}/NEO.emu/target/android-release/build/outputs/apk/release/NeoEmu-release.apk
+        cp target/android-release/build/outputs/apk/release/NeoEmu-release.apk "../EX-Emulators/NeoEmu-${COMMIT_PREFIX}.apk"
 
     - name: Build NES.emu
       if: ${{ matrix.image == 'NES.emu' }}
       run: |
         cd NES.emu
         make -f android-release.mk android-apk V=1 -j`nproc`
-
-    - name: Copy NES.emu artifact
-      if: ${{ matrix.image == 'NES.emu' }}
-      run: |
-        cp NES.emu/target/android-release/build/outputs/apk/release/NesEmu-release.apk EX-Emulators/NesEmu-release.apk
-
-    - name: Upload NES.emu artifact
-      uses: actions/upload-artifact@v3
-      if: ${{ matrix.image == 'NES.emu' }}
-      with:
-        name: NESemu
-        path: ${{ github.workspace }}/NES.emu/target/android-release/build/outputs/apk/release/NesEmu-release.apk
+        cp target/android-release/build/outputs/apk/release/NesEmu-release.apk "../EX-Emulators/NesEmu-${COMMIT_PREFIX}.apk"
 
     - name: Build NGP.emu
       if: ${{ matrix.image == 'NGP.emu' }}
       run: |
         cd NGP.emu
         make -f android-release.mk android-apk V=1 -j`nproc`
-
-    - name: Copy NGP.emu artifact
-      if: ${{ matrix.image == 'NGP.emu' }}
-      run: |
-        cp NGP.emu/target/android-release/build/outputs/apk/release/NgpEmu-release.apk EX-Emulators/NgpEmu-release.apk
-
-    - name: Upload NGP.emu artifact
-      uses: actions/upload-artifact@v3
-      if: ${{ matrix.image == 'NGP.emu' }}
-      with:
-        name: NGPemu
-        path: ${{ github.workspace }}/NGP.emu/target/android-release/build/outputs/apk/release/NgpEmu-release.apk
+        cp target/android-release/build/outputs/apk/release/NgpEmu-release.apk "../EX-Emulators/NgpEmu-${COMMIT_PREFIX}.apk"
 
     - name: Build PCE.emu
       if: ${{ matrix.image == 'PCE.emu' }}
       run: |
         cd PCE.emu
         make -f android-release.mk android-apk V=1 -j`nproc`
-
-    - name: Copy PCE.emu artifact
-      if: ${{ matrix.image == 'PCE.emu' }}
-      run: |
-        cp PCE.emu/target/android-release/build/outputs/apk/release/PceEmu-release.apk EX-Emulators/PceEmu-release.apk
-
-    - name: Upload PCE.emu artifact
-      uses: actions/upload-artifact@v3
-      if: ${{ matrix.image == 'PCE.emu' }}
-      with:
-        name: PCEemu
-        path: ${{ github.workspace }}/PCE.emu/target/android-release/build/outputs/apk/release/PceEmu-release.apk
+        cp target/android-release/build/outputs/apk/release/PceEmu-release.apk "../EX-Emulators/PceEmu-${COMMIT_PREFIX}.apk"
 
     - name: Build Snes9x
       if: ${{ matrix.image == 'Snes9x' }}
       run: |
         cd Snes9x
         make -f android-release.mk android-apk V=1 -j`nproc`
-
-    - name: Copy Snes9x artifact
-      if: ${{ matrix.image == 'Snes9x' }}
-      run: |
-        cp Snes9x/target/android-release/build/outputs/apk/release/Snes9xEXPlus-release.apk EX-Emulators/Snes9xEXPlus-release.apk
-
-    - name: Upload Snes9x artifact
-      uses: actions/upload-artifact@v3
-      if: ${{ matrix.image == 'Snes9x' }}
-      with:
-        name: Snes9x
-        path: ${{ github.workspace }}/Snes9x/target/android-release/build/outputs/apk/release/Snes9xEXPlus-release.apk
+        cp target/android-release/build/outputs/apk/release/Snes9xEXPlus-release.apk "../EX-Emulators/Snes9xEXPlus-${COMMIT_PREFIX}.apk"
 
     - name: Build Snes9x-1.43-9
       if: ${{ matrix.image == 'Snes9x-1.43-9' }}
       run: |
         cd Snes9x/1.43
         make -f android-release-9.mk android-apk V=1 -j`nproc`
-
-    - name: Copy Snes9x-1.43-9 artifact
-      if: ${{ matrix.image == 'Snes9x-1.43-9' }}
-      run: |
-        cp Snes9x/1.43/target/android-release-9/build/outputs/apk/release/Snes9xEX-release.apk EX-Emulators/Snes9xEX-9-release.apk
-
-    - name: Upload Snes9x-1.43-9 artifact
-      uses: actions/upload-artifact@v3
-      if: ${{ matrix.image == 'Snes9x-1.43-9' }}
-      with:
-        name: Snes9x-1.43-9
-        path: ${{ github.workspace }}/Snes9x/1.43/target/android-release-9/build/outputs/apk/release/Snes9xEX-release.apk
+        cp target/android-release-9/build/outputs/apk/release/Snes9xEX-release.apk "../../EX-Emulators/Snes9xEX-9-${COMMIT_PREFIX}.apk"
 
     - name: Build Snes9x-1.43-15
       if: ${{ matrix.image == 'Snes9x-1.43-15' }}
       run: |
         cd Snes9x/1.43
         make -f android-release-15.mk android-apk V=1 -j`nproc`
-
-    - name: Copy Snes9x-1.43-15 artifact
-      if: ${{ matrix.image == 'Snes9x-1.43-15' }}
-      run: |
-        cp Snes9x/1.43/target/android-release-15/build/outputs/apk/release/Snes9xEX-release.apk EX-Emulators/Snes9xEX-15-release.apk
-
-    - name: Upload Snes9x-1.43-15 artifact
-      uses: actions/upload-artifact@v3
-      if: ${{ matrix.image == 'Snes9x-1.43-15' }}
-      with:
-        name: Snes9x-1.43-15
-        path: ${{ github.workspace }}/Snes9x/1.43/target/android-release-15/build/outputs/apk/release/Snes9xEX-release.apk
+        cp target/android-release-15/build/outputs/apk/release/Snes9xEX-release.apk "../../EX-Emulators/Snes9xEX-15-${COMMIT_PREFIX}.apk"
 
     - name: Build Swan.emu
       if: ${{ matrix.image == 'Swan.emu' }}
       run: |
         cd Swan.emu
         make -f android-release.mk android-apk V=1 -j`nproc`
-
-    - name: Copy Swan.emu artifact
-      if: ${{ matrix.image == 'Swan.emu' }}
-      run: |
-        cp Swan.emu/target/android-release/build/outputs/apk/release/SwanEmu-release.apk EX-Emulators/SwanEmu-release.apk
-
-    - name: Upload Swan.emu artifact
-      uses: actions/upload-artifact@v3
-      if: ${{ matrix.image == 'Swan.emu' }}
-      with:
-        name: Swanemu
-        path: ${{ github.workspace }}/Swan.emu/target/android-release/build/outputs/apk/release/SwanEmu-release.apk
+        cp target/android-release/build/outputs/apk/release/SwanEmu-release.apk "../EX-Emulators/SwanEmu-${COMMIT_PREFIX}.apk"
 
     - name: Build Saturn.emu
       if: ${{ matrix.image == 'Saturn.emu' }}
       run: |
         cd Saturn.emu
         make -f android-release.mk android-apk V=1 -j`nproc`
-
-    - name: Copy Saturn.emu artifact
-      if: ${{ matrix.image == 'Saturn.emu' }}
-      run: |
-        cp Saturn.emu/target/android-release/build/outputs/apk/release/SaturnEmu-release.apk EX-Emulators/SaturnEmu-release.apk
-
-    - name: Upload Saturn.emu artifact
-      uses: actions/upload-artifact@v3
-      if: ${{ matrix.image == 'Saturn.emu' }}
-      with:
-        name: Saturnemu
-        path: ${{ github.workspace }}/Saturn.emu/target/android-release/build/outputs/apk/release/SaturnEmu-release.apk
+        cp target/android-release/build/outputs/apk/release/SaturnEmu-release.apk "../EX-Emulators/SaturnEmu-${COMMIT_PREFIX}.apk"
 
     - name: Upload EX-Emulators artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: EX-Emulators
+        name: EX-Emulators-${{ matrix.image }}
         path: EX-Emulators/
 
   release:
@@ -371,20 +196,24 @@ jobs:
         fetch-depth: 0
 
     - name: Download Artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
-        path: dist
+        path: EX-Emulators
+        pattern: EX-Emulators-*
+        merge-multiple: true
 
-    - name: Re-zip artifacts
+    - name: Re-ZIP artifacts
       run: |
-        cd dist
-        for artifact in *
+        mkdir dist
+        cd EX-Emulators
+        for artifact in *.apk
         do
-          echo "-> Creating ${artifact}.zip"
-          pushd "$artifact"
-          zip -r "../${artifact}.zip" *
-          popd
+          file_name="${artifact%.apk}"
+          echo "-> Creating ${file_name}.zip"
+          zip "../dist/${file_name}.zip" "${file_name}.apk"
         done
+        COMMIT_PREFIX=$(echo ${{ github.sha }} | cut -c1-8)
+        zip -r "../dist/EX-Emulators-${COMMIT_PREFIX}.zip" *.apk
 
     - name: Update Git Tag
       run: |


### PR DESCRIPTION
- Upgrade actions/upload-artifact and actions/download-artifact from v3 to v4 for [performance and behavioral benefits](https://github.com/actions/download-artifact?tab=readme-ov-file#v4---whats-new)
- Upload each APK in a general step rather than in a step customized for each APK
- Add the commit hash prefix to file names